### PR TITLE
change shebang line to bash

### DIFF
--- a/nyan.sh
+++ b/nyan.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 function usage() { 
     cat <<EOF


### PR DESCRIPTION
It didn't work on my Ubuntu machine because /bin/sh is dash not bash (and it has some bashishms).
